### PR TITLE
Fix header checking on geoshapes service

### DIFF
--- a/geoshapes.js
+++ b/geoshapes.js
@@ -240,7 +240,7 @@ GeoShapes.prototype.runWikidataQuery = function runWikidataQuery (xClientIp) {
         },
         headers: Object.assign(config.sparqlHeaders, { 'X-Client-IP': xClientIp })
     }).then(queryResult => {
-        if (queryResult.headers['content-type'] !== 'application/sparql-results+json') {
+        if (queryResult.headers['content-type'].indexOf('application/sparql-results+json') === -1) {
             throw new Err('Unexpected content type %s', queryResult.headers['content-type']);
         }
         let data = queryResult.body;

--- a/geoshapes.js
+++ b/geoshapes.js
@@ -240,7 +240,7 @@ GeoShapes.prototype.runWikidataQuery = function runWikidataQuery (xClientIp) {
         },
         headers: Object.assign(config.sparqlHeaders, { 'X-Client-IP': xClientIp })
     }).then(queryResult => {
-        if (queryResult.headers['content-type'].indexOf('application/sparql-results+json') === -1) {
+        if (!queryResult.headers['content-type'].startsWith('application/sparql-results+json')) {
             throw new Err('Unexpected content type %s', queryResult.headers['content-type']);
         }
         let data = queryResult.body;


### PR DESCRIPTION
WDQS is now sending an unexpected header, from this [example](https://en.wikipedia.org/wiki/National_Highway_(India)#/map/0) is possible to extract this [error](https://maps.wikimedia.org/geoline?getgeojson=1&query=%0ASELECT+%3Fid+%3FidLabel%0A%28concat%28%27%5B%5B%27%2C+%3FidLabel%2C+%27%5D%5D%27%29+as+%3Ftitle%29%0AWHERE%0A%7B%0A+++++%3Fid+wdt%3AP31+wd%3AQ34442+.+%23+is+a+road%0A+++++%3Fid+wdt%3AP17+wd%3AQ668+.+%23+in+India%0A+++++%3Fid+wdt%3AP16+wd%3AQ1967342+.+%23+in+India%0A+++++%3Fwikilink+schema%3Aabout+%3Fid%3B+schema%3AisPartOf+%3Chttps%3A%2F%2Fen.wikipedia.org%2F%3E+.%0A++++++SERVICE+wikibase%3Alabel+%7B+bd%3AserviceParam+wikibase%3Alanguage+%27en%27%2C%27ml%27%2C%27hi%27+%7D%0A%7D%0A).

It happens because geoshape service doesn't expect the header `application/sparql-results+json;charset=utf-8`.